### PR TITLE
Listen on all IPv4 interfaces

### DIFF
--- a/src/server/index.cjs
+++ b/src/server/index.cjs
@@ -9,7 +9,7 @@ fastify.register(require("@fastify/static"), {
   root: path.join(__dirname, "..", "..", "dist"),
 });
 
-fastify.listen({ port: 8080 }, function (err, address) {
+fastify.listen({ port: 8080, host: "0.0.0.0" }, function (err, address) {
   if (err) {
     fastify.log.error(err);
     process.exit(1);


### PR DESCRIPTION
The last deployment on Clever Cloud failed because we’re only listening on 127.0.0.1